### PR TITLE
Various fixes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,10 +12,7 @@ keywords = ["ruby", "ruru"]
 license = "MIT"
 
 build = "build/build.rs"
-
-[lib]
-name = "ruru"
-crate-type = ["dylib"]
+links = "ruby"
 
 [dependencies]
 libc = "0.1.12"

--- a/build/build.rs
+++ b/build/build.rs
@@ -9,5 +9,5 @@ fn main() {
 
     let ruby_libdir = String::from_utf8_lossy(&ruby.stdout);
 
-    println!("cargo:rustc-flags=-L {}", ruby_libdir.trim());
+    println!("cargo:rustc-link-search={}", ruby_libdir.trim());
 }

--- a/src/unsafe_binding/array.rs
+++ b/src/unsafe_binding/array.rs
@@ -1,6 +1,5 @@
 use types::{c_long, Value};
 
-#[link(name = "ruby")]
 extern "C" {
     pub fn rb_ary_entry(array: Value, offset: c_long) -> Value;
     pub fn rb_ary_join(array: Value, separator: Value) -> Value;

--- a/src/unsafe_binding/class.rs
+++ b/src/unsafe_binding/class.rs
@@ -1,6 +1,5 @@
 use types::{Argc, c_char, c_int, CallbackPtr, Id, Value};
 
-#[link(name = "ruby")]
 extern "C" {
     pub fn rb_class_new_instance(argc: Argc, argv: *const Value, klass: Value) -> Value;
     pub fn rb_define_class(name: *const c_char, superclass: Value) -> Value;

--- a/src/unsafe_binding/fixnum.rs
+++ b/src/unsafe_binding/fixnum.rs
@@ -1,6 +1,5 @@
 use types::{c_long, SignedValue, Value};
 
-#[link(name = "ruby")]
 extern "C" {
     pub fn rb_int2inum(num: SignedValue) -> Value;
     pub fn rb_num2int(num: Value) -> c_long;


### PR DESCRIPTION
1. use the links key in cargo.toml rather than links attribute
2. don't build as a dylib
3. use rustc-link-search rather than passing -L manually

I am not totally sure about #2, but if I do this, then I end up with `ldd` complaining about

```
	libruru-7038c0b3489c74f7.so => not found
	libstd-cb705824.so => not found
	libruby.so.2.3 => not found
```

whereas, with this, it only complains about libruby.

I still can't 100% get this project to work for me, so we should discuss before merging this in; I get

```
$ ruby example.rb 
example.rb:6:in `call': invalid encoding symbol (EncodingError)
	from example.rb:6:in `<main>'
```

when trying it out. here's my sample: https://github.com/steveklabnik/rust_example/tree/master/ruru (note that i'm using this fork of ruru)