### PR TITLE
Refactor &str to CString conversions

### DIFF
--- a/src/binding/class.rs
+++ b/src/binding/class.rs
@@ -2,12 +2,11 @@ use binding::util::internal_id;
 use types::{Argc, Callback, CallbackPtr, Value};
 use ruby_sys::class::{rb_class_new_instance, rb_define_class, rb_define_method, rb_ivar_get,
                       rb_ivar_set, rb_define_singleton_method, rb_obj_class};
+use util::str_to_cstring;
 use class::traits::Object;
-use std::ffi::CString;
 
 pub fn define_class(name: &str, superclass: Value) -> Value {
-    let string = CString::new(name).unwrap();
-    unsafe { rb_define_class(string.as_ptr(), superclass) }
+    unsafe { rb_define_class(str_to_cstring(name).as_ptr(), superclass) }
 }
 
 pub fn object_class(object: Value) -> Value {
@@ -27,17 +26,18 @@ pub fn instance_variable_set(object: Value, name: &str, value: Value) -> Value {
 }
 
 pub fn define_method<I: Object, O: Object>(klass: Value, name: &str, callback: Callback<I, O>) {
-    let string = CString::new(name).unwrap();
     unsafe {
-        rb_define_method(klass, string.as_ptr(), callback as CallbackPtr, -1);
+        rb_define_method(klass, str_to_cstring(name).as_ptr(), callback as CallbackPtr, -1);
     }
 }
 
 pub fn define_singleton_method<I: Object, O: Object>(klass: Value,
                                                      name: &str,
                                                      callback: Callback<I, O>) {
-    let string = CString::new(name).unwrap();
     unsafe {
-        rb_define_singleton_method(klass, string.as_ptr(), callback as CallbackPtr, -1);
+        rb_define_singleton_method(klass,
+                                   str_to_cstring(name).as_ptr(),
+                                   callback as CallbackPtr,
+                                   -1);
     }
 }

--- a/src/binding/string.rs
+++ b/src/binding/string.rs
@@ -1,12 +1,9 @@
 use types::Value;
 use ruby_sys::string::{rb_str_new_cstr, rb_string_value_cstr};
-use util::cstr_as_string;
-use std::ffi::CString;
+use util::{cstr_as_string, str_to_cstring};
 
 pub fn new(string: &str) -> Value {
-    let string = CString::new(string).unwrap();
-
-    unsafe { rb_str_new_cstr(string.as_ptr()) }
+    unsafe { rb_str_new_cstr(str_to_cstring(string).as_ptr()) }
 }
 
 pub fn from_value(value: Value) -> String {

--- a/src/binding/util.rs
+++ b/src/binding/util.rs
@@ -1,7 +1,7 @@
 use binding::global::rb_cObject;
 use types::{Argc, Id, Value};
 use ruby_sys::util::{rb_const_get, rb_funcallv, rb_intern};
-use std::ffi::CString;
+use util::str_to_cstring;
 
 pub fn get_constant(name: &str, _parent_object: Value) -> Value {
     let constant_id = internal_id(name);
@@ -10,13 +10,7 @@ pub fn get_constant(name: &str, _parent_object: Value) -> Value {
 }
 
 pub fn internal_id(string: &str) -> Id {
-    let string = CString::new(string).unwrap();
-    let id;
-    {
-        id = unsafe { rb_intern(string.as_ptr()) };
-    }
-
-    id
+    unsafe { rb_intern(str_to_cstring(string).as_ptr()) }
 }
 
 pub fn call_method(receiver: Value, method: &str, argc: Argc, argv: *const Value) -> Value {

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,4 +1,4 @@
-use std::ffi::CStr;
+use std::ffi::{CStr, CString};
 
 use binding::global::RubySpecialConsts;
 use class::any_object::AnyObject;
@@ -8,6 +8,10 @@ use class::traits::Object;
 
 pub fn cstr_as_string(str: *const c_char) -> String {
     unsafe { CStr::from_ptr(str).to_string_lossy().into_owned() }
+}
+
+pub fn str_to_cstring(str: &str) -> CString {
+    CString::new(str).unwrap()
 }
 
 pub fn bool_to_value(state: bool) -> Value {


### PR DESCRIPTION
 - Create `util::str_to_cstring` function

@steveklabnik, a small clean up for the hacking session #4 😄 

Trying to DRY up the `CString` handling. Similar approach worked fine for `Vec -> ptr` conversions (1b9932904646741229a683d86a0e7761ab02a41f)