### PR TITLE
Add AnyObject.get_type

### DIFF
--- a/ruby-sys/src/types.rs
+++ b/ruby-sys/src/types.rs
@@ -8,6 +8,38 @@ pub type Value = uintptr_t;
 pub type SignedValue = intptr_t;
 pub type Id = uintptr_t;
 
+#[derive(Debug, PartialEq)]
+#[link_name = "ruby_value_type"]
+#[repr(C)]
+pub enum ValueType {
+    None = 0x00,
+    Object = 0x01,
+    Class = 0x02,
+    Module = 0x03,
+    Float = 0x04,
+    RString = 0x05,
+    Regexp = 0x06,
+    Array = 0x07,
+    Hash = 0x08,
+    Struct = 0x09,
+    Bignum = 0x0a,
+    File = 0x0b,
+    Data = 0x0c,
+    Match = 0x0d,
+    Complex = 0x0e,
+    Rational = 0x0f,
+    Nil = 0x11,
+    True = 0x12,
+    False = 0x13,
+    Symbol = 0x14,
+    Fixnum = 0x15,
+    Undef = 0x1b,
+    Node = 0x1c,
+    IClass = 0x1d,
+    Zombie = 0x1e,
+    Mask = 0x1f,
+}
+
 pub type Argc = c_int;
 
 pub type CallbackPtr = *const c_void;

--- a/ruby-sys/src/util.rs
+++ b/ruby-sys/src/util.rs
@@ -27,29 +27,29 @@ pub enum RubySpecialConsts {
     SymbolFlag = 0x0c,
 }
 
-pub const SPECIAL_SHIFT: usize = 8;
+const SPECIAL_SHIFT: usize = 8;
 
-pub fn rb_value_is_fixnum(value: Value) -> bool {
+fn rb_value_is_fixnum(value: Value) -> bool {
     (value & (RubySpecialConsts::FixnumFlag as usize)) != 0
 }
 
-pub fn rb_value_is_flonum(value: Value) -> bool {
+fn rb_value_is_flonum(value: Value) -> bool {
     (value & (RubySpecialConsts::FlonumMask as usize)) == (RubySpecialConsts::FlonumFlag as usize)
 }
 
-pub fn rb_value_is_immediate(value: Value) -> bool {
+fn rb_value_is_immediate(value: Value) -> bool {
     (value & (RubySpecialConsts::ImmediateMask as usize)) != 0
 }
 
-pub fn rb_value_is_static_sym(value: Value) -> bool {
+fn rb_value_is_static_sym(value: Value) -> bool {
     (value & !((!0) << SPECIAL_SHIFT)) == (RubySpecialConsts::SymbolFlag as usize)
 }
 
-pub fn rb_test(value: Value) -> bool {
+fn rb_test(value: Value) -> bool {
     (value & !(RubySpecialConsts::Nil as usize)) != 0
 }
 
-pub fn rb_builtin_type(value: Value) -> ValueType {
+fn rb_builtin_type(value: Value) -> ValueType {
     unsafe {
         let basic: *const RBasic = mem::transmute(value);
         let masked = (*basic).flags & (ValueType::Mask as size_t);

--- a/ruby-sys/src/util.rs
+++ b/ruby-sys/src/util.rs
@@ -1,7 +1,86 @@
-use types::{Argc, c_char, Id, Value};
+use libc::size_t;
+use std::mem;
+use types::{Argc, c_char, Id, Value, ValueType};
 
 extern "C" {
     pub fn rb_const_get(klass: Value, id: Id) -> Value;
     pub fn rb_funcallv(receiver: Value, method: Value, argc: Argc, argv: *const Value) -> Value;
     pub fn rb_intern(name: *const c_char) -> Id;
+}
+
+#[repr(C)]
+struct RBasic {
+    flags: Value,
+    klass: Value,
+}
+
+pub enum RubySpecialConsts {
+    False = 0,
+    True = 0x14,
+    Nil = 0x08,
+    Undef = 0x34,
+
+    ImmediateMask = 0x07,
+    FixnumFlag = 0x01,
+    FlonumMask = 0x03,
+    FlonumFlag = 0x02,
+    SymbolFlag = 0x0c,
+}
+
+pub const SPECIAL_SHIFT: usize = 8;
+
+pub fn rb_value_is_fixnum(value: Value) -> bool {
+    (value & (RubySpecialConsts::FixnumFlag as usize)) != 0
+}
+
+pub fn rb_value_is_flonum(value: Value) -> bool {
+    (value & (RubySpecialConsts::FlonumMask as usize)) == (RubySpecialConsts::FlonumFlag as usize)
+}
+
+pub fn rb_value_is_immediate(value: Value) -> bool {
+    (value & (RubySpecialConsts::ImmediateMask as usize)) != 0
+}
+
+pub fn rb_value_is_static_sym(value: Value) -> bool {
+    (value & !((!0) << SPECIAL_SHIFT)) == (RubySpecialConsts::SymbolFlag as usize)
+}
+
+pub fn rb_test(value: Value) -> bool {
+    (value & !(RubySpecialConsts::Nil as usize)) != 0
+}
+
+pub fn rb_builtin_type(value: Value) -> ValueType {
+    unsafe {
+        let basic: *const RBasic = mem::transmute(value);
+        let masked = (*basic).flags & (ValueType::Mask as size_t);
+        mem::transmute(masked as u32)
+    }
+}
+
+pub fn rb_type(value: Value) -> ValueType {
+    if rb_value_is_immediate(value) {
+        if rb_value_is_fixnum(value) {
+            ValueType::Fixnum
+        } else if rb_value_is_flonum(value) {
+            ValueType::Float
+        } else if value == (RubySpecialConsts::True as usize) {
+            ValueType::True
+        } else if rb_value_is_static_sym(value) {
+            ValueType::Symbol
+        } else if value == (RubySpecialConsts::Undef as usize) {
+            ValueType::Undef
+        } else {
+            rb_builtin_type(value)
+        }
+    } else if !rb_test(value) {
+        if value == (RubySpecialConsts::Nil as usize) {
+            ValueType::Nil
+        } else if value == (RubySpecialConsts::False as usize) {
+            ValueType::False
+        } else {
+            rb_builtin_type(value)
+        }
+    } else {
+        rb_builtin_type(value)
+    }
 }

--- a/src/binding/global.rs
+++ b/src/binding/global.rs
@@ -1,6 +1,2 @@
 pub use ruby_sys::rb_cObject;
-
-pub enum RubySpecialConsts {
-    False = 0,
-    True = 0x14,
-}
+pub use ruby_sys::util::RubySpecialConsts;

--- a/src/binding/util.rs
+++ b/src/binding/util.rs
@@ -1,8 +1,9 @@
 use binding::global::rb_cObject;
 use types::{Argc, Id, Value};
 use ruby_sys::util::{rb_const_get, rb_funcallv, rb_intern};
-pub use ruby_sys::util::rb_type as get_type;
 use util::str_to_cstring;
+
+pub use ruby_sys::util::rb_type as get_type;
 
 pub fn get_constant(name: &str, _parent_object: Value) -> Value {
     let constant_id = internal_id(name);

--- a/src/binding/util.rs
+++ b/src/binding/util.rs
@@ -1,6 +1,7 @@
 use binding::global::rb_cObject;
 use types::{Argc, Id, Value};
 use ruby_sys::util::{rb_const_get, rb_funcallv, rb_intern};
+pub use ruby_sys::util::rb_type as get_type;
 use util::str_to_cstring;
 
 pub fn get_constant(name: &str, _parent_object: Value) -> Value {

--- a/src/class/any_object.rs
+++ b/src/class/any_object.rs
@@ -1,4 +1,5 @@
-use types::Value;
+use binding::util::get_type;
+use types::{Value, ValueType};
 
 use super::traits::Object;
 
@@ -92,6 +93,24 @@ impl AnyObject {
     /// ```
     pub fn to<T: Object>(&self) -> T {
         T::from(self.value)
+    }
+
+    /// Determines the value type of the object
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use ruru::{AnyObject, Fixnum, VM};
+    /// use ruru::traits::Object;
+    /// use ruru::types::ValueType;
+    /// # VM::init();
+    ///
+    /// let any_object = Fixnum::new(1).to_any_object();
+    ///
+    /// assert_eq!(any_object.get_type(), ValueType::Fixnum);
+    /// ```
+    pub fn get_type(&self) -> ValueType {
+        get_type(self.value())
     }
 }
 

--- a/src/class/any_object.rs
+++ b/src/class/any_object.rs
@@ -107,9 +107,9 @@ impl AnyObject {
     ///
     /// let any_object = Fixnum::new(1).to_any_object();
     ///
-    /// assert_eq!(any_object.get_type(), ValueType::Fixnum);
+    /// assert_eq!(any_object.ty(), ValueType::Fixnum);
     /// ```
-    pub fn get_type(&self) -> ValueType {
+    pub fn ty(&self) -> ValueType {
         get_type(self.value())
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,9 +1,9 @@
 use ruby_sys::types;
-pub use ruby_sys::types::ValueType;
 
 use class::any_object::AnyObject;
 
 pub use libc::{c_char, c_int, c_long};
+pub use ruby_sys::types::ValueType;
 
 pub type Value = types::Value;
 pub type SignedValue = types::SignedValue;

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,4 +1,5 @@
 use ruby_sys::types;
+pub use ruby_sys::types::ValueType;
 
 use class::any_object::AnyObject;
 


### PR DESCRIPTION
This adds a Rust port of C macros (from Ruby 2.3.1's `ruby/ruby.h`) that determines the type of a given `Value`. `AnyObject.get_type` is a helper method for this implementation.

The implementation of `rb_builtin_type` comes from https://github.com/jdm/ruby-mri-rs.

I'm not convinced that the changes are organized in the best manner, so I would be happy to move things around. Otherwise, it's working pretty well in the Rust + Ruby extension I converted from a Rust + C + Ruby hybrid.