### PR TITLE
Use travis-cargo to run tests & build docs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,19 @@ rust:
   - stable
   - beta
   - nightly
+cache: cargo
 matrix:
   allow_failures:
     - rust: nightly
+before_script:
+- |
+  pip install 'travis-cargo<0.2' --user &&
+  export PATH=$HOME/.local/bin:$PATH
+script:
+- |
+  travis-cargo build &&
+  travis-cargo test &&
+  travis-cargo --only stable doc
+env:
+  global:
+  - TRAVIS_CARGO_NIGHTLY_FEATURE=""


### PR DESCRIPTION
This will allow @d-unseductable to automatically upload docs when there are new commits to master (assuming he adds an `after_success` section and the encrypted `GH_TOKEN` per the [travis-cargo docs](https://github.com/huonw/travis-cargo#example)).