### PR TITLE
Move to Option

### DIFF
--- a/src/class/any_object.rs
+++ b/src/class/any_object.rs
@@ -30,7 +30,7 @@ use super::traits::Object;
 /// # VM::init();
 ///
 /// let array = Array::new().push(Fixnum::new(1));
-/// let value = array.at(0).to::<Fixnum>(); // `Array::at()` returns `AnyObject`
+/// let value = array.at(0).unwrap().to::<Fixnum>(); // `Array::at()` returns `AnyObject`
 ///
 /// assert_eq!(value.to_i64(), 1);
 /// ```
@@ -46,7 +46,7 @@ use super::traits::Object;
 /// hash.store(Symbol::new("key"), Fixnum::new(1));
 ///
 /// // `Hash::at()` returns `AnyObject`
-/// let value = hash.at(Symbol::new("key")).to::<Fixnum>();
+/// let value = hash.at(Symbol::new("key")).unwrap().to::<Fixnum>();
 ///
 /// assert_eq!(value, Fixnum::new(1));
 /// ```

--- a/src/class/array.rs
+++ b/src/class/array.rs
@@ -34,7 +34,7 @@ impl Array {
         Array { value: new() }
     }
 
-    /// Retrieves an `AnyObject` from element at `index` position.
+    /// Retrieves an `Option` with an `AnyObject` from element at `index` position.
     ///
     /// # Examples
     ///
@@ -44,7 +44,7 @@ impl Array {
     ///
     /// let array = Array::new().push(Fixnum::new(1));
     ///
-    /// assert_eq!(array.at(0).to::<Fixnum>(), Fixnum::new(1));
+    /// assert_eq!(array.at(0).unwrap().to::<Fixnum>(), Fixnum::new(1));
     /// ```
     ///
     /// Ruby:
@@ -54,10 +54,14 @@ impl Array {
     ///
     /// array[0] == 1
     /// ```
-    pub fn at(&self, index: i64) -> AnyObject {
-        let value = entry(self.value(), index);
+    pub fn at(&self, index: i64) -> Option<AnyObject> {
+        let value = AnyObject::from(entry(self.value(), index));
 
-        AnyObject::from(value)
+        if value.value().is_nil() || value.value().is_undef(){
+            None
+        } else {
+            Some(value)
+        }
     }
 
     /// Joins all elements of `Array` to Ruby `String`.
@@ -103,7 +107,7 @@ impl Array {
     ///
     /// array.push(Fixnum::new(1));
     ///
-    /// assert_eq!(array.at(0).to::<Fixnum>(), Fixnum::new(1));
+    /// assert_eq!(array.at(0).unwrap().to::<Fixnum>(), Fixnum::new(1));
     /// ```
     ///
     /// Ruby:
@@ -132,7 +136,7 @@ impl Array {
     ///
     /// array.store(0, Fixnum::new(2));
     ///
-    /// assert_eq!(array.at(0).to::<Fixnum>(), Fixnum::new(2));
+    /// assert_eq!(array.at(0).unwrap().to::<Fixnum>(), Fixnum::new(2));
     /// ```
     ///
     /// Ruby:

--- a/src/class/hash.rs
+++ b/src/class/hash.rs
@@ -32,7 +32,7 @@ impl Hash {
         Hash { value: new() }
     }
 
-    /// Retrieves an `AnyObject` from element stored at `key` key.
+    /// Retrieves an `Option` with an `AnyObject` from element stored at `key` key.
     ///
     /// # Examples
     ///
@@ -44,7 +44,7 @@ impl Hash {
     ///
     /// hash.store(Symbol::new("key"), Fixnum::new(1));
     ///
-    /// assert_eq!(hash.at(Symbol::new("key")).to::<Fixnum>(), Fixnum::new(1));
+    /// assert_eq!(hash.at(Symbol::new("key")).unwrap().to::<Fixnum>(), Fixnum::new(1));
     /// ```
     ///
     /// Ruby:
@@ -55,10 +55,13 @@ impl Hash {
     ///
     /// hash[:key] == 1
     /// ```
-    pub fn at<T: Object>(&self, key: T) -> AnyObject {
-        let value = aref(self.value(), key.value());
-
-        AnyObject::from(value)
+    pub fn at<T: Object>(&self, key: T) -> Option<AnyObject> {
+        let value = AnyObject::from(aref(self.value(), key.value()));
+        if value.value().is_nil() || value.value().is_undef(){
+            None
+        } else {
+            Some(value)
+        }
     }
 
     /// Associates the `value` with the `key`.
@@ -75,7 +78,7 @@ impl Hash {
     ///
     /// hash.store(Symbol::new("key"), Fixnum::new(1));
     ///
-    /// assert_eq!(hash.at(Symbol::new("key")).to::<Fixnum>(), Fixnum::new(1));
+    /// assert_eq!(hash.at(Symbol::new("key")).unwrap().to::<Fixnum>(), Fixnum::new(1));
     /// ```
     ///
     /// Ruby:


### PR DESCRIPTION
Dearest Reviewer,

This change closes #21 which talks about optional return values. In ruby
an index for an array or hash can be something or nil. When using rust I
feel like using an Option will prevent user from need to use ruby's type
checking.

Either way thanks for the review.

Becker