### PR TITLE
Ensure num_to_int always returns i64

### DIFF
--- a/src/binding/fixnum.rs
+++ b/src/binding/fixnum.rs
@@ -6,5 +6,6 @@ pub fn int_to_num(num: i64) -> Value {
 }
 
 pub fn num_to_int(num: Value) -> i64 {
-    unsafe { rb_num2int(num) }
+    unsafe { rb_num2int(num) as i64 }
+
 }


### PR DESCRIPTION
On Windows, `c_long` is `i32` (regardless of arch) so compilation fails without the cast.