### PR TITLE
AppVeyor: Use another way of determining the Rust stable version

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -49,19 +49,11 @@ install:
         }
         if ($env:RUST_VERSION -eq 'stable') {
           echo "Downloading $channel channel manifest";
-          $manifest = "${env:Temp}\channel-rust-stable";
-          Start-FileDownload "https://static.rust-lang.org/dist/channel-rust-stable" -FileName "$manifest";
+          Start-FileDownload "https://static.rust-lang.org/dist/channel-rust-stable";
 
-          # Search the manifest lines for the correct filename based on expanded arch
-          $match = Get-Content "$manifest" | Select-String -pattern "${arch_expanded}.exe" -simplematch;
-          if (!$match -or !$match.line) {
-            throw "Could not find ${arch_expanded} in stable channel manifest";
-          }
-
-          $env:rust_installer = $match.line;
-        } else {
-          $env:rust_installer = "rust-${env:RUST_VERSION}-${arch_expanded}.exe";
+          $env:RUST_VERSION = Get-Content channel-rust-stable | Select -first 1 | %{$_.split('-')[1]}
         }
+        $env:rust_installer = "rust-${env:RUST_VERSION}-${arch_expanded}.exe";
   - curl --show-error --location --retry 5 --output rust-installer.exe https://static.rust-lang.org/dist/%rust_installer%
   - .\rust-installer.exe /VERYSILENT /NORESTART /DIR="C:\rust"
   - call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" %ARCH%


### PR DESCRIPTION
This way does not freeze after downloading the manifest. (I noticed this behavior in a bunch of my Rust projects, even the non-Ruru related ones.) As a bonus, it's less lines of code.

Originally from: https://github.com/booyaa/cathulhu/blob/9009b14/appveyor.yml#L39-L40