### PR TITLE
Initial wrap of Ruby's `Float`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,5 +12,5 @@ keywords = ["cruby", "mri", "ruby", "ruru"]
 license = "MIT"
 
 [dependencies]
-ruby-sys = "0.2.15"
+ruby-sys = "0.2.16"
 lazy_static = "0.2.1"

--- a/src/binding/float.rs
+++ b/src/binding/float.rs
@@ -1,0 +1,11 @@
+use ruby_sys::float;
+
+use types::Value;
+
+pub fn float_to_num(num: f64) -> Value {
+    unsafe { float::rb_float_new(num) }
+}
+
+pub fn num_to_float(num: Value) -> f64 {
+    unsafe { float::rb_num2dbl(num) as f64 }
+}

--- a/src/binding/mod.rs
+++ b/src/binding/mod.rs
@@ -1,6 +1,7 @@
 pub mod array;
 pub mod class;
 pub mod fixnum;
+pub mod float;
 pub mod gc;
 pub mod global;
 pub mod hash;

--- a/src/class/float.rs
+++ b/src/class/float.rs
@@ -1,0 +1,81 @@
+use std::convert::From;
+
+use binding::float;
+use types::{Value, ValueType};
+
+use {Object, VerifiedObject};
+
+/// `Float`
+#[derive(Debug, PartialEq)]
+pub struct Float {
+    value: Value,
+}
+
+impl Float {
+    /// Creates a new `Float`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use ruru::{Float, VM};
+    /// # VM::init();
+    ///
+    /// let float = Float::new(1.23);
+    ///
+    /// assert_eq!(float.to_f64(), 1.23);
+    /// ```
+    ///
+    /// Ruby:
+    ///
+    /// ```ruby
+    /// 1.23 == 1.23
+    /// ```
+    pub fn new(num: f64) -> Self {
+        Self::from(float::float_to_num(num))
+    }
+
+    /// Retrieves an `f64` value from `Float`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use ruru::{Float, VM};
+    /// # VM::init();
+    ///
+    /// let float = Float::new(1.23);
+    ///
+    /// assert_eq!(float.to_f64(), 1.23);
+    /// ```
+    ///
+    /// Ruby:
+    ///
+    /// ```ruby
+    /// 1.23 == 1.23
+    /// ```
+    pub fn to_f64(&self) -> f64 {
+        float::num_to_float(self.value())
+    }
+}
+
+impl From<Value> for Float {
+    fn from(value: Value) -> Self {
+        Float { value: value }
+    }
+}
+
+impl Object for Float {
+    #[inline]
+    fn value(&self) -> Value {
+        self.value
+    }
+}
+
+impl VerifiedObject for Float {
+    fn is_correct_type<T: Object>(object: &T) -> bool {
+        object.value().ty() == ValueType::Float
+    }
+
+    fn error_message() -> &'static str {
+        "Error converting to Float"
+    }
+}

--- a/src/class/mod.rs
+++ b/src/class/mod.rs
@@ -3,6 +3,7 @@ pub mod array;
 pub mod boolean;
 pub mod class;
 pub mod fixnum;
+pub mod float;
 pub mod gc;
 pub mod hash;
 pub mod nil_class;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,7 @@ pub use class::array::Array;
 pub use class::boolean::Boolean;
 pub use class::class::Class;
 pub use class::fixnum::Fixnum;
+pub use class::float::Float;
 pub use class::gc::GC;
 pub use class::hash::Hash;
 pub use class::nil_class::NilClass;


### PR DESCRIPTION
Adds basic converting to and from Rust’s `f64`. I "borrowed" code from `fixnum`, so examples/doctests are the same (more or less) and didn't add any other examples. Hope that's ok... 

I am, however, getting 3 test failures locally with 2.2.5 (tested with ruby 2.2.5, 2.3.1, and 2.4.0-preview2):

```
ruru git:master ❯ cargo test                                                                                                                                                               ✹ ✭ [ruby-2.2.5]
   Compiling libc v0.2.17
   Compiling lazy_static v0.2.1
   Compiling ruby-sys v0.2.16
   Compiling ruru v0.9.0 (file:///Users/sloveless/Development/not_my_projects/ruru)
    Finished debug [unoptimized + debuginfo] target(s) in 2.68 secs
     Running target/debug/deps/ruru-e07d35424d9cef87

running 1 test
test it_works ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured

   Doc-tests ruru

running 90 tests
test class::array::Array::length_0 ... ok
test class::array::Array::dup_0 ... ok
test class::array::Array::join_0 ... ok
test class::any_object::AnyObject_0 ... ok
test class::array::Array::at_0 ... ok
test class::any_object::AnyObject_1 ... ok
test class::array::Array::concat_0 ... ok
test class::array::Array::new_0 ... ok
test class!_0 ... ok
test class::array::Array::pop_0 ... ok
test class::array::Array::reverse_bang_0 ... ok
test class::array::Array::push_0 ... ok
test class::array::Array::reverse_0 ... ok
test class::array::Array::shift_0 ... ok
test class::array::Array::sort_bang_0 ... ok
test class::array::Array::sort_0 ... ok
test class::array::Array::to_s_0 ... ok
test class::array::Array::store_0 ... ok
test class::boolean::Boolean::new_0 ... ok
test class::array::Array_0 ... ok
test class::array::Array::unshift_0 ... ok
test class::boolean::Boolean::to_bool_0 ... ok
test class::class::Class::attr_accessor_0 ... ok
test class::class::Class::attr_reader_0 ... ok
test class::class::Class::attr_writer_0 ... ok
test class::class::Class::define_nested_class_0 ... ok
test class::class::Class::ancestors_1 ... ok
test class::class::Class::ancestors_0 ... ok
test class::class::Class::new_instance_0 ... ok
test class::class::Class::from_existing_0 ... ok
test class::array::Array_0 ... ok
test class::class::Class::get_nested_class_0 ... ok
test class::class::Class::new_0 ... ok
test class::fixnum::Fixnum::new_0 ... ok
test class::float::Float::new_0 ... ok
test class::fixnum::Fixnum::to_i64_0 ... ok
test class::class::Class::superclass_0 ... ok
test class::float::Float::to_f64_0 ... ok
test class::gc::GC::mark_0 ... ok
test class::hash::Hash::new_0 ... ok
test class::class::Class_0 ... ok
test class::hash::Hash::at_0 ... ok
test class::hash::Hash::length_0 ... ok
test class::nil_class::NilClass::new_0 ... ok
test class::rproc::Proc::call_0 ... ok
test class::string::RString::to_string_unchecked_0 ... ok
test class::class::Class::wrap_data_0 ... FAILED
test class::hash::Hash::store_0 ... ok
test class::string::RString::bytesize_0 ... ok
test class::hash::Hash::each_0 ... ok
test class::string::RString::to_string_0 ... ok
test class::string::RString::new_0 ... ok
test class::traits::object::Object::define_0 ... ok
test class::traits::object::Object::class_0 ... ok
test class::symbol::Symbol::new_0 ... ok
test class::traits::object::Object::define_1 ... ok
test class::symbol::Symbol::to_string_0 ... ok
test class::traits::object::Object::define_method_0 ... ok
test class::traits::object::Object::define_singleton_method_1 ... ok
test class::traits::object::Object::is_nil_0 ... ok
test class::traits::object::Object::define_method_1 ... ok
test class::traits::object::Object::define_singleton_method_0 ... ok
test class::traits::object::Object::respond_to_0 ... ok
test class::traits::object::Object::singleton_class_0 ... ok
test class::traits::object::Object::singleton_class_1 ... ok
test class::traits::object::Object::instance_variable_get_0 ... ok
test class::traits::object::Object::instance_variable_set_0 ... ok
test class::traits::object::Object::to_0 ... ok
test class::traits::object::Object::get_data_0 ... FAILED
test class::traits::object::Object::send_0 ... ok
test class::traits::object::Object::try_convert_to_1 ... ok
test class::traits::object::Object::value_0 ... ok
test class::traits::object::Object::ty_0 ... ok
test class::traits::object::Object::to_any_object_0 ... ok
test class::vm::VM::init_0 ... ok
test class::vm::VM::block_proc_0 ... ok
test class::vm::VM::raise_0 ... ok
test class::vm::VM::parse_arguments_0 ... ok
test class::vm::VM::raise_1 ... ok
test wrappable_struct!_0 ... ignored
test wrappable_struct!_1 ... ignored
test wrappable_struct!_2 ... ignored
test class::traits::object::Object::try_convert_to_0 ... ok
test class::vm::VM::require_0 ... ok
test class::vm::VM::thread_call_without_gvl_0 ... ok
test unsafe_methods!_0 ... ok
test result::Error::to_exception_0 ... ok
test class::traits::verified_object::VerifiedObject_0 ... ok
test methods!_0 ... ok
test wrappable_struct!_3 ... FAILED

failures:

---- class::class::Class::wrap_data_0 stdout ----
        warning: unused variable: `itself`, #[warn(unused_variables)] on by default
  --> <ruru macros>:7:73
   |
7  | argc : $ crate :: types :: Argc , argv : * const $ crate :: AnyObject , mut $
   |                                                                         ^
<anon>:33:1: 55:3 note: in this expansion of methods! (defined in <ruru macros>)

error: linking with `cc` failed: exit code: 1
  |
  = note: "cc" "-m64" "-L" "/Users/sloveless/.multirust/toolchains/stable-x86_64-apple-darwin/lib/rustlib/x86_64-apple-darwin/lib" "/var/folders/yk/5ycshs415xx5j0w61z_nfjgc0000gn/T/rustdoctest.Sz5JpAafuQb3/rust_out.0.o" "-o" "/var/folders/yk/5ycshs415xx5j0w61z_nfjgc0000gn/T/rustdoctest.Sz5JpAafuQb3/rust_out" "-Wl,-dead_strip" "-nodefaultlibs" "-L" "/Users/sloveless/Development/not_my_projects/ruru/target/debug/deps" "-L" "/Users/sloveless/.rubies/ruby-2.2.5/lib" "-L" "/Users/sloveless/.multirust/toolchains/stable-x86_64-apple-darwin/lib/rustlib/x86_64-apple-darwin/lib" "/Users/sloveless/Development/not_my_projects/ruru/target/debug/deps/libruru.rlib" "/Users/sloveless/Development/not_my_projects/ruru/target/debug/deps/liblazy_static-359f5533c970cd71.rlib" "/Users/sloveless/Development/not_my_projects/ruru/target/debug/deps/libruby_sys-78627ab62acf82d5.rlib" "/Users/sloveless/Development/not_my_projects/ruru/target/debug/deps/liblibc-ad32fde1bd850538.rlib" "-L" "/Users/sloveless/.multirust/toolchains/stable-x86_64-apple-darwin/lib/rustlib/x86_64-apple-darwin/lib" "-l" "std-40393716" "-l" "ruby.2.2.0" "-l" "System" "-l" "pthread" "-l" "c" "-l" "m" "-l" "compiler-rt"
  = note: Undefined symbols for architecture x86_64:
  "_rb_data_typed_object_wrap", referenced from:
      ruru::binding::class::wrap_data::hfac80d63ef74e6c8 in rust_out.0.o
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)


error: aborting due to previous error

thread 'class::class::Class::wrap_data_0' panicked at 'Box<Any>', ../src/librustc_errors/lib.rs:672
note: Run with `RUST_BACKTRACE=1` for a backtrace.
thread 'class::class::Class::wrap_data_0' panicked at 'couldn't compile the test', ../src/librustdoc/test.rs:282

---- class::traits::object::Object::get_data_0 stdout ----
        warning: unused variable: `itself`, #[warn(unused_variables)] on by default
  --> <ruru macros>:7:73
   |
7  | argc : $ crate :: types :: Argc , argv : * const $ crate :: AnyObject , mut $
   |                                                                         ^
<anon>:33:1: 55:3 note: in this expansion of methods! (defined in <ruru macros>)

error: linking with `cc` failed: exit code: 1
  |
  = note: "cc" "-m64" "-L" "/Users/sloveless/.multirust/toolchains/stable-x86_64-apple-darwin/lib/rustlib/x86_64-apple-darwin/lib" "/var/folders/yk/5ycshs415xx5j0w61z_nfjgc0000gn/T/rustdoctest.2yz5axvDN2RI/rust_out.0.o" "-o" "/var/folders/yk/5ycshs415xx5j0w61z_nfjgc0000gn/T/rustdoctest.2yz5axvDN2RI/rust_out" "-Wl,-dead_strip" "-nodefaultlibs" "-L" "/Users/sloveless/Development/not_my_projects/ruru/target/debug/deps" "-L" "/Users/sloveless/.rubies/ruby-2.2.5/lib" "-L" "/Users/sloveless/.multirust/toolchains/stable-x86_64-apple-darwin/lib/rustlib/x86_64-apple-darwin/lib" "/Users/sloveless/Development/not_my_projects/ruru/target/debug/deps/libruru.rlib" "/Users/sloveless/Development/not_my_projects/ruru/target/debug/deps/liblazy_static-359f5533c970cd71.rlib" "/Users/sloveless/Development/not_my_projects/ruru/target/debug/deps/libruby_sys-78627ab62acf82d5.rlib" "/Users/sloveless/Development/not_my_projects/ruru/target/debug/deps/liblibc-ad32fde1bd850538.rlib" "-L" "/Users/sloveless/.multirust/toolchains/stable-x86_64-apple-darwin/lib/rustlib/x86_64-apple-darwin/lib" "-l" "std-40393716" "-l" "ruby.2.2.0" "-l" "System" "-l" "pthread" "-l" "c" "-l" "m" "-l" "compiler-rt"
  = note: Undefined symbols for architecture x86_64:
  "_rb_data_typed_object_wrap", referenced from:
      ruru::binding::class::wrap_data::hfac80d63ef74e6c8 in rust_out.0.o
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)


error: aborting due to previous error

thread 'class::traits::object::Object::get_data_0' panicked at 'Box<Any>', ../src/librustc_errors/lib.rs:672
thread 'class::traits::object::Object::get_data_0' panicked at 'couldn't compile the test', ../src/librustdoc/test.rs:282

---- wrappable_struct!_3 stdout ----
        warning: unused variable: `itself`, #[warn(unused_variables)] on by default
  --> <ruru macros>:7:73
   |
7  | argc : $ crate :: types :: Argc , argv : * const $ crate :: AnyObject , mut $
   |                                                                         ^
<anon>:33:1: 55:3 note: in this expansion of methods! (defined in <ruru macros>)

error: linking with `cc` failed: exit code: 1
  |
  = note: "cc" "-m64" "-L" "/Users/sloveless/.multirust/toolchains/stable-x86_64-apple-darwin/lib/rustlib/x86_64-apple-darwin/lib" "/var/folders/yk/5ycshs415xx5j0w61z_nfjgc0000gn/T/rustdoctest.Nrq84twpVSkx/rust_out.0.o" "-o" "/var/folders/yk/5ycshs415xx5j0w61z_nfjgc0000gn/T/rustdoctest.Nrq84twpVSkx/rust_out" "-Wl,-dead_strip" "-nodefaultlibs" "-L" "/Users/sloveless/Development/not_my_projects/ruru/target/debug/deps" "-L" "/Users/sloveless/.rubies/ruby-2.2.5/lib" "-L" "/Users/sloveless/.multirust/toolchains/stable-x86_64-apple-darwin/lib/rustlib/x86_64-apple-darwin/lib" "/Users/sloveless/Development/not_my_projects/ruru/target/debug/deps/libruru.rlib" "/Users/sloveless/Development/not_my_projects/ruru/target/debug/deps/liblazy_static-359f5533c970cd71.rlib" "/Users/sloveless/Development/not_my_projects/ruru/target/debug/deps/libruby_sys-78627ab62acf82d5.rlib" "/Users/sloveless/Development/not_my_projects/ruru/target/debug/deps/liblibc-ad32fde1bd850538.rlib" "-L" "/Users/sloveless/.multirust/toolchains/stable-x86_64-apple-darwin/lib/rustlib/x86_64-apple-darwin/lib" "-l" "std-40393716" "-l" "ruby.2.2.0" "-l" "System" "-l" "pthread" "-l" "c" "-l" "m" "-l" "compiler-rt"
  = note: Undefined symbols for architecture x86_64:
  "_rb_data_typed_object_wrap", referenced from:
      ruru::binding::class::wrap_data::hfac80d63ef74e6c8 in rust_out.0.o
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)


error: aborting due to previous error

thread 'wrappable_struct!_3' panicked at 'Box<Any>', ../src/librustc_errors/lib.rs:672
thread 'wrappable_struct!_3' panicked at 'couldn't compile the test', ../src/librustdoc/test.rs:282


failures:
    class::class::Class::wrap_data_0
    class::traits::object::Object::get_data_0
    wrappable_struct!_3

test result: FAILED. 84 passed; 3 failed; 3 ignored; 0 measured

error: test failed
```