### PR TITLE
Add From<String> for RString

### DIFF
--- a/src/class/string.rs
+++ b/src/class/string.rs
@@ -179,6 +179,12 @@ impl From<Value> for RString {
     }
 }
 
+impl From<String> for RString {
+    fn from(string: String) -> Self {
+        Self::new(string.as_str())
+    }
+}
+
 impl Object for RString {
     #[inline]
     fn value(&self) -> Value {


### PR DESCRIPTION
Minor addition for slightly more ergonomic code. This:

    RString::new(fn_that_returns_string().as_str())

Becomes just:

    RString::new(fn_that_returns_string())