### PR TITLE
Fix possible segfault issue when using threads

### DIFF
--- a/src/binding/thread.rs
+++ b/src/binding/thread.rs
@@ -11,7 +11,7 @@ use types::RawFd;
 use ::Object;
 
 pub fn create<F, R>(func: F) -> Value
-    where F: FnOnce() -> R,
+    where F: 'static + FnOnce() -> R,
           R: Object
 {
     let fnbox = Box::new(func) as Box<FnOnce() -> R>;
@@ -27,8 +27,8 @@ pub fn wait_fd(fd: RawFd) {
 }
 
 pub fn call_without_gvl<F, R, G>(func: F, unblock_func: Option<G>) -> R
-    where F: FnOnce() -> R,
-          G: FnOnce()
+    where F: 'static + FnOnce() -> R,
+          G: 'static + FnOnce()
 {
     unsafe {
         let ptr = if let Some(ubf) = unblock_func {
@@ -48,8 +48,8 @@ pub fn call_without_gvl<F, R, G>(func: F, unblock_func: Option<G>) -> R
 }
 
 pub fn call_without_gvl2<F, R, G>(func: F, unblock_func: Option<G>) -> R
-    where F: FnOnce() -> R,
-          G: FnOnce()
+    where F: 'static + FnOnce() -> R,
+          G: 'static + FnOnce()
 {
     unsafe {
         let ptr = if let Some(ubf) = unblock_func {
@@ -69,7 +69,7 @@ pub fn call_without_gvl2<F, R, G>(func: F, unblock_func: Option<G>) -> R
 }
 
 pub fn call_with_gvl<F, R>(func: F) -> R
-    where F: FnOnce() -> R
+    where F: 'static + FnOnce() -> R
 {
     unsafe {
         let ptr = thread::rb_thread_call_with_gvl(thread_call_callbox as CallbackPtr,

--- a/src/class/thread.rs
+++ b/src/class/thread.rs
@@ -42,7 +42,7 @@ impl Thread {
     /// end
     /// ```
     pub fn new<F, R>(func: F) -> Self
-        where F: FnOnce() -> R,
+        where F: 'static + FnOnce() -> R,
               R: Object
     {
         Self::from(thread::create(func))
@@ -115,21 +115,21 @@ impl Thread {
     /// }
     /// ```
     pub fn call_without_gvl<F, R, G>(func: F, unblock_func: Option<G>) -> R
-        where F: FnOnce() -> R,
-              G: FnOnce()
+        where F: 'static + FnOnce() -> R,
+              G: 'static + FnOnce()
     {
         thread::call_without_gvl(func, unblock_func)
     }
 
     pub fn call_without_gvl2<F, R, G>(func: F, unblock_func: Option<G>) -> R
-        where F: FnOnce() -> R,
-              G: FnOnce()
+        where F: 'static + FnOnce() -> R,
+              G: 'static + FnOnce()
     {
         thread::call_without_gvl2(func, unblock_func)
     }
 
     pub fn call_with_gvl<F, R>(func: F) -> R
-        where F: FnOnce() -> R
+        where F: 'static + FnOnce() -> R
     {
         thread::call_with_gvl(func)
     }


### PR DESCRIPTION
This adds `'static` bounds to the closures passed into thread creation methods. The `'static` bound is necessary to prevent non-moving closures from being used. As evident from #64, it was possible to violate Rust's ownership model without the `'static` bounds.

Resolves #64.