### PR TITLE
Add RString#new_utf8 and string::new_utf8

### DIFF
--- a/src/binding/string.rs
+++ b/src/binding/string.rs
@@ -10,6 +10,13 @@ pub fn new(string: &str) -> Value {
     unsafe { string::rb_str_new(str, len) }
 }
 
+pub fn new_utf8(string: &str) -> Value {
+    let str = string.as_ptr() as *const c_char;
+    let len = string.len() as c_long;
+
+    unsafe { string::rb_utf8_str_new(str, len) }
+}
+
 pub fn value_to_string(value: Value) -> String {
     unsafe {
         let str = string::rb_string_value_cstr(&value);

--- a/src/class/string.rs
+++ b/src/class/string.rs
@@ -36,6 +36,31 @@ impl RString {
         Self::from(string::new(string))
     }
 
+    /// Creates a new instance of Ruby `String`, with UTF8 encoding, containing
+    /// given `string`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use ruru::{RString, VM};
+    /// # VM::init();
+    ///
+    /// let string = RString::new_utf8("Hello, World!");
+    ///
+    /// assert_eq!(string.to_string(), "Hello, World!".to_string());
+    /// ```
+    ///
+    /// Ruby:
+    ///
+    /// ```ruby
+    /// str = 'Hello, World!'
+    ///
+    /// str == 'Hello, World!'
+    /// ```
+    pub fn new_utf8(string: &str) -> Self {
+        Self::from(string::new_utf8(string))
+    }
+
     /// Retrieves underlying Rust `String` from Ruby `String` object.
     ///
     /// # Examples


### PR DESCRIPTION
These functions will return a new Ruby string with UTF8 encoding. This is for the issue described in d-unseductable/ruru#67