### PR TITLE
Code Triage badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 [![Build Status](https://travis-ci.org/d-unseductable/ruru.svg?branch=master)](https://travis-ci.org/d-unseductable/ruru)
 [![Build status](https://ci.appveyor.com/api/projects/status/2epyqhooimdu6u5l?svg=true)](https://ci.appveyor.com/project/d-unseductable/ruru)
 [![Gitter](https://badges.gitter.im/rust-ruru/general.svg)](https://gitter.im/rust-ruru/general?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
+[![Code Triagers Badge](https://www.codetriage.com/d-unseductable/ruru/badges/users.svg)](https://www.codetriage.com/d-unseductable/ruru)
 
 <p align="center">
   <img src="http://this-week-in-ruru.org/assets/images/logo.png" width="350" height="350">


### PR DESCRIPTION
Code Triage allows people to receive emails of random project issues in their email daily to help them motivate themselves into contributing and helping the project advance.  This badge shows the number of people who've subscribed to the issue mailings.  Note that some people may just be interested in the issues themselves rather than contributing.  Still this is an ideal way to volunteer.