### PR TITLE
Protect send: a panic safe feature for Ruby interaction

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,5 +12,5 @@ keywords = ["cruby", "mri", "ruby", "ruru"]
 license = "MIT"
 
 [dependencies]
-ruby-sys = "0.3.0"
+ruby-sys = { git = "https://github.com/steveklabnik/ruby-sys", branch = "master" }
 lazy_static = "0.2.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,5 +12,5 @@ keywords = ["cruby", "mri", "ruby", "ruru"]
 license = "MIT"
 
 [dependencies]
-ruby-sys = { git = "https://github.com/steveklabnik/ruby-sys", branch = "master" }
+ruby-sys = { git = "https://github.com/danielpclark/ruby-sys", branch = "playground" }
 lazy_static = "0.2.1"

--- a/src/binding/util.rs
+++ b/src/binding/util.rs
@@ -22,3 +22,11 @@ pub fn call_method(receiver: Value, method: &str, arguments: Option<Vec<Value>>)
     // TODO: Update the signature of `rb_funcallv` in ruby-sys to receive an `Option`
     unsafe { ruby_sys_util::rb_funcallv(receiver, method_id, argc, argv) }
 }
+
+pub fn call_public_method(receiver: Value, method: &str, arguments: Option<Vec<Value>>) -> Value {
+    let (argc, argv) = util::process_arguments(&arguments);
+    let method_id = internal_id(method);
+
+    // TODO: Update the signature of `rb_funcallv_public` in ruby-sys to receive an `Option`
+    unsafe { ruby_sys_util::rb_funcallv_public(receiver, method_id, argc, argv) }
+}

--- a/src/binding/vm.rs
+++ b/src/binding/vm.rs
@@ -29,6 +29,31 @@ pub fn require(name: &str) {
     }
 }
 
+// "evaluation can raise an exception."
+pub fn eval_string(string: &str) -> Value {
+    let s = util::str_to_cstring(string);
+
+    unsafe {
+        vm::rb_eval_string(s.as_ptr())
+    }
+}
+
+pub fn eval_string_protect(string: &str) -> Result<Value, c_int> {
+    let s = util::str_to_cstring(string);
+    let mut state = 0;
+    let value = unsafe {
+        vm::rb_eval_string_protect(
+            s.as_ptr(),
+            &mut state as *mut c_int
+        )
+    };
+    if state == 0 {
+      Ok(value)
+    } else {
+      Err(state)
+    }
+}
+
 pub fn raise(exception: Value, message: &str) {
     let message = util::str_to_cstring(message);
 

--- a/src/binding/vm.rs
+++ b/src/binding/vm.rs
@@ -66,8 +66,6 @@ pub fn errinfo() -> Value {
     unsafe { vm::rb_errinfo() }
 }
 
-// TODO: Implement passing raised exception into Ruby
-#[allow(dead_code)]
 pub fn set_errinfo(err: Value) {
     unsafe { vm::rb_set_errinfo(err) }
 }
@@ -143,9 +141,9 @@ extern "C" fn callbox(boxptr: *mut c_void) -> *const c_void {
     fnbox()
 }
 
-pub fn protect<F>(func: F) -> Result<Value, c_int>
+pub fn protect<F, R>(func: F) -> Result<Value, c_int>
 where
-    F: FnOnce(),
+    F: FnOnce() -> R,
 {
     let mut state = 0;
     let value = unsafe {

--- a/src/binding/vm.rs
+++ b/src/binding/vm.rs
@@ -48,9 +48,9 @@ pub fn eval_string_protect(string: &str) -> Result<Value, c_int> {
         )
     };
     if state == 0 {
-      Ok(value)
+        Ok(value)
     } else {
-      Err(state)
+        Err(state)
     }
 }
 
@@ -60,6 +60,16 @@ pub fn raise(exception: Value, message: &str) {
     unsafe {
         vm::rb_raise(exception, message.as_ptr());
     }
+}
+
+pub fn errinfo() -> Value {
+    unsafe { vm::rb_errinfo() }
+}
+
+// TODO: Implement passing raised exception into Ruby
+#[allow(dead_code)]
+pub fn set_errinfo(err: Value) {
+    unsafe { vm::rb_set_errinfo(err) }
 }
 
 pub fn thread_call_without_gvl<F, R, G>(func: F, unblock_func: Option<G>) -> R

--- a/src/class/vm.rs
+++ b/src/class/vm.rs
@@ -3,7 +3,7 @@ use std::slice;
 use binding::vm;
 use types::{Argc, Value};
 
-use {AnyObject, Class, Object, Proc};
+use {AnyObject, Class, Object, Proc, NilClass};
 
 /// Virtual Machine and helpers
 pub struct VM;
@@ -161,9 +161,14 @@ impl VM {
     pub fn eval(string: &str) -> Result<AnyObject, AnyObject> {
         vm::eval_string_protect(string).map(|v|
             AnyObject::from(v)
-        ).map_err(|_|
-            AnyObject::from(vm::errinfo())
-        )
+        ).map_err(|_| {
+            let output = AnyObject::from(vm::errinfo());
+
+            // error cleanup
+            vm::set_errinfo(NilClass::new().value());
+
+            output
+        })
     }
 
     /// Evals string and returns an AnyObject

--- a/src/class/vm.rs
+++ b/src/class/vm.rs
@@ -129,6 +129,32 @@ impl VM {
     /// }
     /// ```
     ///
+    /// `Err` will return an `AnyObject` of the exception class raised.
+    /// 
+    /// 
+    /// ```
+    /// #[macro_use]
+    /// extern crate ruru;
+    ///
+    /// use ruru::{Class, Fixnum, Object, RString, VM};
+    ///
+    /// fn main() {
+    ///     # VM::init();
+    ///
+    ///     let result = VM::eval("raise IndexError, 'flowers'");
+    ///     
+    ///     match result {
+    ///       Err(ao) => {
+    ///         let err = Class::from(ao.value());
+    ///         let message = err.send("message", None);
+    ///         let s = message.try_convert_to::<RString>();
+    ///         assert_eq!(s.ok().unwrap().to_string(), "flowers");
+    ///       },
+    ///       _ => { unreachable!() }
+    ///     }
+    /// }
+    /// ```
+    ///
     /// Be aware when checking for equality amongst types like strings, that even
     /// with the same content in Ruby, they will evaluate to different values in
     /// C/Rust.

--- a/src/class/vm.rs
+++ b/src/class/vm.rs
@@ -1,7 +1,7 @@
 use std::slice;
 
 use binding::vm;
-use types::{Argc, Value, c_int};
+use types::{Argc, Value};
 
 use {AnyObject, Class, Object, Proc};
 
@@ -132,9 +132,11 @@ impl VM {
     /// Be aware when checking for equality amongst types like strings, that even
     /// with the same content in Ruby, they will evaluate to different values in
     /// C/Rust.
-    pub fn eval(string: &str) -> Result<AnyObject, c_int> {
+    pub fn eval(string: &str) -> Result<AnyObject, AnyObject> {
         vm::eval_string_protect(string).map(|v|
             AnyObject::from(v)
+        ).map_err(|_|
+            AnyObject::from(vm::errinfo())
         )
     }
 

--- a/src/class/vm.rs
+++ b/src/class/vm.rs
@@ -130,8 +130,8 @@ impl VM {
     /// ```
     ///
     /// `Err` will return an `AnyObject` of the exception class raised.
-    /// 
-    /// 
+    ///
+    ///
     /// ```
     /// #[macro_use]
     /// extern crate ruru;
@@ -142,7 +142,7 @@ impl VM {
     ///     # VM::init();
     ///
     ///     let result = VM::eval("raise IndexError, 'flowers'");
-    ///     
+    ///
     ///     match result {
     ///       Err(ao) => {
     ///         let err = Class::from(ao.value());


### PR DESCRIPTION
_This is forked off of the eval PR._  After ruby-sys is updated I'll fix the `Cargo.toml` file.

Provides
* `Object#protect_send` -> `Result<AnyObject, AnyObject>`
* `Object#protect_public_send` -> `Result<AnyObject, AnyObject>`

Methods can be called with these just like with send except instead of crashing when Ruby raises/throws an exception we can now handle the exception on the `Err` path.

### TODO

* [ ] Wait for `ruby-sys` update and update `Cargo.toml`