### PR TITLE
Re-export ruby-sys test feature and pass it on test builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ before_script:
 script:
 - |
   travis-cargo build &&
-  travis-cargo test
+  travis-cargo test --features=test
 
 env:
   global:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,6 @@ license = "MIT"
 [dependencies]
 ruby-sys = "0.3.0"
 lazy_static = "0.2.1"
+
+[features]
+test = ["ruby-sys/test"]


### PR DESCRIPTION
This accompanies https://github.com/steveklabnik/ruby-sys/pull/31.

Basically a re-export of a `ruby-sys` feature I added to conditionally link `libruby` when it's needed (for running Rust tests). Normally `libruby` isn't needed due to how the interpreter dynamically loads c-extensions (see https://github.com/steveklabnik/ruby-sys/pull/25).